### PR TITLE
[readme][s]: Add a deprecation notice at the top of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## :warning: Deprecation notice
+
+**The datapipes website is now archived and read-only.** The `gh-pages` branch hosts the content of the static version of the website, which is now available at [datapipes.datopian.com](https://datapipes.datopian.com/).
+
+## datapipes
+
 A node library, command line tool and webapp to provide "pipe-able" Unix-Style
 data transformations on row-based data like CSVs.
 


### PR DESCRIPTION
Checking in before merging straight into `master` to ensure that this displays the information we want.

* Add a new heading explaining that the website is being deprecated.
* Link to the static website and point out that the `gh-pages` branch is
  hosting the content.

Please let me know if we should change the message. :slightly_smiling_face:

/cc @rufuspollock 